### PR TITLE
Fixed bug calling .setData the first time - .addSeries called instead

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject re-frame-highcharts "0.1.3-SNAPSHOT"
+(defproject andrew-nguyen/re-frame-highcharts "0.1.3-SNAPSHOT"
   :description "A simple utility helper to use Highcharts with re-frame"
   :url "https://github.com/cfelde/re-frame-highcharts"
   :license {:name "Eclipse Public License"
@@ -113,4 +113,4 @@
                    :clean-targets ^{:protect false} ["resources/public/js/compiled"
                                                      :target-path]}}
 
-  :signing {:gpg-key "cfelde@cfelde.com"})
+  )


### PR DESCRIPTION
Not sure if you had this problem with an older version of Highcharts but I tried including your example in my project and kept getting a "calling .setData on undefined" error the first time the component is loaded.

In the proposed version, if series is nil, call `.addSeries` instead.