### PR TITLE
Update library calls to use Reagent 1.0.0 rather than 0.8.1.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -8,7 +8,7 @@
 
   :dependencies [[org.clojure/clojure "1.9.0"]
                  [org.clojure/clojurescript "1.10.439"]
-                 [reagent  "0.8.1"]
+                 [reagent  "1.0.0"]
                  [re-frame "0.10.6"]
 
                  ; Server side stuff

--- a/src/re_frame_highcharts/example.cljs
+++ b/src/re_frame_highcharts/example.cljs
@@ -1,5 +1,6 @@
 (ns re-frame-highcharts.example
   (:require [reagent.core :as reagent]
+            [reagent.dom]
             [re-frame.core :as rf]
             [re-frame-highcharts.utils :as chart-utils]
             [re-frame-highcharts.example-data :as example-data]))
@@ -138,5 +139,5 @@
   [type]
   (rf/dispatch-sync [:initialize])
   (case type
-    "charts" (reagent/render-component [charts-ui] (js/document.getElementById "app"))
-    "stock" (reagent/render-component [stock-ui] (js/document.getElementById "app"))))
+    "charts" (reagent.dom/render [charts-ui] (js/document.getElementById "app"))
+    "stock"  (reagent.dom/render [stock-ui]  (js/document.getElementById "app"))))

--- a/src/re_frame_highcharts/utils.cljs
+++ b/src/re_frame_highcharts/utils.cljs
@@ -1,5 +1,6 @@
 (ns re-frame-highcharts.utils
-  (:require [reagent.core :as reagent]))
+  (:require [reagent.core :as reagent]
+            [reagent.dom]))
 
 ; Highcharts wants to maintain its own instance, with mutating state.
 ; So we'll need to break from our lovely pure world and manage these.
@@ -17,7 +18,7 @@
               [this]
               (let [[_ {:keys [chart-meta chart-data]}] (reagent/argv this)
                     chart-id (:id chart-meta)
-                    chart-instance (js/Highcharts.Chart. (reagent/dom-node this)
+                    chart-instance (js/Highcharts.Chart. (reagent.dom/dom-node this)
                                                          (clj->js chart-data))]
                 (swap! chart-instances assoc chart-id chart-instance)))
             (ensure-series
@@ -53,7 +54,7 @@
               [this]
               (let [[_ {:keys [chart-meta chart-data]}] (reagent/argv this)
                     chart-id (:id chart-meta)
-                    chart-instance (js/Highcharts.StockChart. (reagent/dom-node this)
+                    chart-instance (js/Highcharts.StockChart. (reagent.dom/dom-node this)
                                                               (clj->js chart-data))]
                 (swap! stock-instances assoc chart-id chart-instance)))
             (ensure-series


### PR DESCRIPTION
 Reagent moved a few library calls around in the 1.0.0 version. This updates re-frame-highcharts to use Reagent 1.0.0.